### PR TITLE
Update for tomland-1.3.0

### DIFF
--- a/src/Config/Error.hs
+++ b/src/Config/Error.hs
@@ -3,12 +3,12 @@ module Config.Error
     ) where
 
 import Control.Exception (IOException)
-import Toml (DecodeException)
+import Toml (TomlDecodeError)
 
 data ConfigError
     = IOError IOException
     | Disabled
     | InvalidPath
     | MissingApiKey
-    | ParseError DecodeException
+    | ParseError [TomlDecodeError]
     deriving (Show, Eq)


### PR DESCRIPTION
tomland-1.3.0 renames `DecodeException` to `TomlDecodeError`. This fixes the import to allow compilation against `>= tomland-1.3.0`.