### PR TITLE
Upgrade to current LTS stack

### DIFF
--- a/ntfd.cabal
+++ b/ntfd.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1791f4900b353472b60f8341699d027b2c0265ec1056c5841c62ab71ade9bcc7
+-- hash: d78900261f0784b00ad04fe973cedf3d329043b49741fb70f9683c0bff52e8bb
 
 name:           ntfd
-version:        0.2.2
+version:        0.2.3
 description:    Please see the README on GitHub at <https://github.com/kamek-pf/ntfd#readme>
 homepage:       https://github.com/kamek-pf/ntfd#readme
 bug-reports:    https://github.com/kamek-pf/ntfd/issues
@@ -44,7 +44,12 @@ library
       Paths_ntfd
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings RecordWildCards NamedFieldPuns ScopedTypeVariables TupleSections
+  default-extensions:
+      OverloadedStrings
+      RecordWildCards
+      NamedFieldPuns
+      ScopedTypeVariables
+      TupleSections
   ghc-options: -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wcompat -Widentities -Wredundant-constraints -Wmissing-export-lists -Wpartial-fields
   build-depends:
       aeson
@@ -75,7 +80,12 @@ executable ntfd
       Paths_ntfd
   hs-source-dirs:
       app
-  default-extensions: OverloadedStrings RecordWildCards NamedFieldPuns ScopedTypeVariables TupleSections
+  default-extensions:
+      OverloadedStrings
+      RecordWildCards
+      NamedFieldPuns
+      ScopedTypeVariables
+      TupleSections
   ghc-options: -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wcompat -Widentities -Wredundant-constraints -Wmissing-export-lists -Wpartial-fields -threaded
   build-depends:
       aeson
@@ -111,7 +121,12 @@ test-suite ntfd-test
       Paths_ntfd
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings RecordWildCards NamedFieldPuns ScopedTypeVariables TupleSections
+  default-extensions:
+      OverloadedStrings
+      RecordWildCards
+      NamedFieldPuns
+      ScopedTypeVariables
+      TupleSections
   ghc-options: -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wcompat -Widentities -Wredundant-constraints -Wmissing-export-lists -Wpartial-fields -Wno-incomplete-uni-patterns -Wno-missing-export-lists -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                ntfd
-version:             0.2.2
+version:             0.2.3
 github:              "kamek-pf/ntfd"
 license:             GPL-3
 author:              "Bertrand Bousquet"

--- a/src/Config/Error.hs
+++ b/src/Config/Error.hs
@@ -3,12 +3,12 @@ module Config.Error
     ) where
 
 import Control.Exception (IOException)
-import Toml (DecodeException)
+import Toml (TomlDecodeError)
 
 data ConfigError
     = IOError IOException
     | Disabled
     | InvalidPath
     | MissingApiKey
-    | ParseError DecodeException
+    | ParseError [TomlDecodeError]
     deriving (Show, Eq)

--- a/src/Stores/Github.hs
+++ b/src/Stores/Github.hs
@@ -16,7 +16,7 @@ import Data.Either (rights)
 import Data.List ((\\))
 import Data.Text (Text)
 import Data.Text.Lazy (toStrict, fromStrict)
-import GHC.Natural (intToNatural)
+import GHC.Natural (naturalFromInteger)
 import Numeric.Natural (Natural)
 import Text.Microstache (compileMustacheText, renderMustacheW, MustacheWarning)
 import Text.Parsec (ParseError)
@@ -94,8 +94,8 @@ instance Store GithubClient where
         cfg            = config s
         mvar           = internalState s
         template       = githubTemplate cfg
-        unreadCount    = intToNatural . length
-        firstTimeCount = intToNatural . length . filter isNew
+        unreadCount    = naturalFromInteger . fromIntegral . length
+        firstTimeCount = naturalFromInteger . fromIntegral . length . filter isNew
         shouldNotify maybeOldState newState = case maybeOldState of
             Just oldState -> notificationIds newState \\ notificationIds oldState
             Nothing       -> notificationIds newState

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-15.13
+resolver: lts-21.22
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -40,13 +40,16 @@ packages:
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
 extra-deps:
-- http-io-streams-0.1.3.0@sha256:5f15ccff61f7a15cefc85f00b34b05605b660f5f54be38c76cebf5e3a81300af,3231
-- base64-bytestring-1.1.0.0@sha256:190264fef9e65d9085f00ccda419137096d1dc94777c58272bc96821dc7f37c3,2334
+  - libmpd-0.10.0.0@sha256:8985142b1109edb0d10b10ee3d26299cea0510c9d4f18993f5ce552f92d32905,3907
+  - tomland-1.3.3.2@sha256:887dc39a8c9819deb8fcb6fde72e87dad4c94108b1736a5bf7215ccf3117bd0f,9474
+  - validation-selective-0.2.0.0@sha256:e1ab5482dede8bf676d729a09109c7c5f798363b9d458e4197a27afb8b48fdd3,3907
+
+allow-newer: true
+allow-newer-deps:
+  - libmpd
 
 # Override default flag values for local packages and extra-deps
-flags:
-  http-io-streams:
-    brotli: false
+#flags:
 
 # Extra package databases containing global packages
 # extra-package-dbs: []

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,22 +5,29 @@
 
 packages:
 - completed:
-    hackage: http-io-streams-0.1.3.0@sha256:5f15ccff61f7a15cefc85f00b34b05605b660f5f54be38c76cebf5e3a81300af,3231
+    hackage: libmpd-0.10.0.0@sha256:8985142b1109edb0d10b10ee3d26299cea0510c9d4f18993f5ce552f92d32905,3907
     pantry-tree:
-      size: 883
-      sha256: b0d7020ac1c841ec7632b274a15c52a232c1781e0f3650bba105d5de141efd38
+      sha256: e60ed79e1712974aa72c10a060da35cc899952b4001d6eb40f52c35085b84b89
+      size: 3772
   original:
-    hackage: http-io-streams-0.1.3.0@sha256:5f15ccff61f7a15cefc85f00b34b05605b660f5f54be38c76cebf5e3a81300af,3231
+    hackage: libmpd-0.10.0.0@sha256:8985142b1109edb0d10b10ee3d26299cea0510c9d4f18993f5ce552f92d32905,3907
 - completed:
-    hackage: base64-bytestring-1.1.0.0@sha256:190264fef9e65d9085f00ccda419137096d1dc94777c58272bc96821dc7f37c3,2334
+    hackage: tomland-1.3.3.2@sha256:887dc39a8c9819deb8fcb6fde72e87dad4c94108b1736a5bf7215ccf3117bd0f,9474
     pantry-tree:
-      size: 850
-      sha256: 9ade5b5911df97c37b249b84f123297049f19578cae171c647bf47683633427c
+      sha256: 09b5c00b3b129ff3ead6a57489d1c5af24567ab9d08399ab3bf53f43affcc60b
+      size: 6430
   original:
-    hackage: base64-bytestring-1.1.0.0@sha256:190264fef9e65d9085f00ccda419137096d1dc94777c58272bc96821dc7f37c3,2334
+    hackage: tomland-1.3.3.2@sha256:887dc39a8c9819deb8fcb6fde72e87dad4c94108b1736a5bf7215ccf3117bd0f,9474
+- completed:
+    hackage: validation-selective-0.2.0.0@sha256:e1ab5482dede8bf676d729a09109c7c5f798363b9d458e4197a27afb8b48fdd3,3907
+    pantry-tree:
+      sha256: c5f1ddcb6a721cdb12cdec1e12af3ad7dcc936745e3fd53e5dd09b4a12b83bd5
+      size: 697
+  original:
+    hackage: validation-selective-0.2.0.0@sha256:e1ab5482dede8bf676d729a09109c7c5f798363b9d458e4197a27afb8b48fdd3,3907
 snapshots:
 - completed:
-    size: 496112
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/13.yaml
-    sha256: 75a1a0f870e1876898b117b0e443f911b3fa2985bfabb53158c81ab5765beda5
-  original: lts-15.13
+    sha256: afd5ba64ab602cabc2d3942d3d7e7dd6311bc626dcb415b901eaf576cb62f0ea
+    size: 640060
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/22.yaml
+  original: lts-21.22


### PR DESCRIPTION
Bump the stack resolver to 21.22, which is the current LTS. This required two changes, one for a newer `tomland`, and one for dealing with the updated `base`.